### PR TITLE
#6 resolve name for claims principal

### DIFF
--- a/src/Easify.Ef.UnitTests/Extensions/PrincipalExtensionsTests.cs
+++ b/src/Easify.Ef.UnitTests/Extensions/PrincipalExtensionsTests.cs
@@ -1,20 +1,22 @@
 // This software is part of the Easify.Ef Library
 // Copyright (C) 2018 Intermediate Capital Group
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
+using System.Collections.Generic;
+using System.Security.Claims;
 using System.Security.Principal;
 using Easify.Ef.Extensions;
 using FluentAssertions;
@@ -38,6 +40,20 @@ namespace Easify.Ef.UnitTests.Extensions
 
             // Assert
             actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void Should_GetUserName_ReturnTheCorrectUserFromClaimsPrincipal()
+        {
+            //Arrange
+            var identity = new ClaimsIdentity(new[] {new Claim(ClaimTypes.Name, "n/a")}, "Federated", ClaimTypes.NameIdentifier, ClaimTypes.Role);
+            var claimsPrincipal = new ClaimsPrincipal(identity);
+
+            //Act
+            var actual = claimsPrincipal.GetUserName();
+
+            //Assert
+            actual.Should().Be("n/a");
         }
     }
 }

--- a/src/Easify.Ef/Extensions/PrincipalExtensions.cs
+++ b/src/Easify.Ef/Extensions/PrincipalExtensions.cs
@@ -1,20 +1,22 @@
 // This software is part of the Easify.Ef Library
 // Copyright (C) 2018 Intermediate Capital Group
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
-// 
+//
 
+using System.Linq;
+using System.Security.Claims;
 using System.Security.Principal;
 
 namespace Easify.Ef.Extensions
@@ -26,10 +28,14 @@ namespace Easify.Ef.Extensions
         public static string GetUserName(this IPrincipal principal)
         {
             var identity = principal?.Identity;
-            if (identity == null)
+            if (identity == null || identity.IsAuthenticated == false)
                 return AnonymousUser;
 
-            return identity.IsAuthenticated == false ? AnonymousUser : identity.Name;
+            if (!string.IsNullOrWhiteSpace(identity.Name)) return identity.Name;
+            if (!(identity is ClaimsIdentity claimsIdentity)) return AnonymousUser;
+
+            var claim = claimsIdentity.Claims.FirstOrDefault(c => c.Type == ClaimTypes.Name);
+            return claim?.Value ?? AnonymousUser;
         }
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

This change fixes a bug in Easify EF where we were not able to resolve the username from ClaimsPrincipal.



_Mo and I worked on this a while ago, Ive just realised I hadn't merged this in_ 