### PR TITLE
Migration to EF Core 3.1 and Easify 3.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.0.{build}
+version: 3.0.{build}
 pull_requests:
   do_not_increment_build_number: true
 image: Visual Studio 2019

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: 1.0.{build}
 pull_requests:
   do_not_increment_build_number: true
-image: Previous Visual Studio 2017
+image: Visual Studio 2019
 dotnet_csproj:
   patch: true
   file: '**\*.csproj'

--- a/src/Easify.Ef.Testing.UnitTests/Easify.Ef.Testing.UnitTests.csproj
+++ b/src/Easify.Ef.Testing.UnitTests/Easify.Ef.Testing.UnitTests.csproj
@@ -1,15 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <IsPackable>false</IsPackable>
+        <LangVersion>8</LangVersion>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.10.3" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.4" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-        <PackageReference Include="NSubstitute" Version="4.2.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.9" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+        <PackageReference Include="NSubstitute" Version="4.2.2" />
         <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     </ItemGroup>
     <ItemGroup>

--- a/src/Easify.Ef.Testing/Builders/TypeMapper.cs
+++ b/src/Easify.Ef.Testing/Builders/TypeMapper.cs
@@ -23,12 +23,11 @@ namespace Easify.Ef.Testing.Builders
 {
     public class TypeMapper : ITypeMapper
     {
-        private readonly Action<IMapperConfigurationExpression> _configurator;
         private readonly IMapper _mapper;
             
         public TypeMapper(Action<IMapperConfigurationExpression> configurator)
         {
-            _configurator = configurator;
+            if (configurator == null) throw new ArgumentNullException(nameof(configurator));
             _mapper = MapperBuilder.Build(configurator);
         }
 

--- a/src/Easify.Ef.Testing/Easify.Ef.Testing.csproj
+++ b/src/Easify.Ef.Testing/Easify.Ef.Testing.csproj
@@ -8,10 +8,12 @@
     <PackageProjectUrl>https://github.com/icgam/Easify.Ef</PackageProjectUrl>
     <RepositoryUrl>https://github.com/icgam/Easify.Ef</RepositoryUrl>
     <Version>1.0.0</Version>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="6.2.2" />
-    <PackageReference Include="NSubstitute" Version="4.2.1" />
+    <PackageReference Include="AutoMapper" Version="10.1.1" />
+    <PackageReference Include="Easify" Version="3.0.1" />
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Easify.Ef.UnitTests/Easify.Ef.UnitTests.csproj
+++ b/src/Easify.Ef.UnitTests/Easify.Ef.UnitTests.csproj
@@ -1,14 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
       <IsPackable>false</IsPackable>
+      <LangVersion>8</LangVersion>
   </PropertyGroup>
   <ItemGroup>
       <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-      <PackageReference Include="NSubstitute" Version="4.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+      <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Easify.Ef.Testing\Easify.Ef.Testing.csproj" />

--- a/src/Easify.Ef.UnitTests/Extensions/RepositoryExtensionsTests.cs
+++ b/src/Easify.Ef.UnitTests/Extensions/RepositoryExtensionsTests.cs
@@ -19,6 +19,7 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
+using Easify.Ef.Extensions;
 using Easify.Ef.UnitTests.Models;
 using Easify.Extensions.Specifications;
 using EfCore.UnitOfWork;
@@ -41,7 +42,7 @@ namespace Easify.Ef.UnitTests.Extensions
             var expression = spec.ToExpression();
 
             // Act
-            Easify.Ef.Extensions.RepositoryExtensions.GetList(repository, spec, q => q);
+            repository.GetList(spec, q => q);
 
             // Assert
             repository.Received(1).GetList(Arg.Is((Expression<Func<SampleEntity, bool>> m)  => m.ToString() == expression.ToString()),
@@ -60,7 +61,7 @@ namespace Easify.Ef.UnitTests.Extensions
             var expression = spec.ToExpression();
 
             // Act
-            await Easify.Ef.Extensions.RepositoryExtensions.GetListAsync(repository, spec, q => q);
+            await repository.GetListAsync(spec, q => q);
 
             // Assert
             await repository.Received(1).GetListAsync(Arg.Is((Expression<Func<SampleEntity, bool>> m)  => m.ToString() == expression.ToString()),
@@ -79,7 +80,7 @@ namespace Easify.Ef.UnitTests.Extensions
             var expression = spec.ToExpression();
 
             // Act
-            Easify.Ef.Extensions.RepositoryExtensions.GetFirstOrDefault(repository, spec, q => q);
+            repository.GetFirstOrDefault(spec, q => q);
 
             // Assert
             repository.Received(1).GetFirstOrDefault(Arg.Is((Expression<Func<SampleEntity, bool>> m)  => m.ToString() == expression.ToString()),
@@ -98,7 +99,7 @@ namespace Easify.Ef.UnitTests.Extensions
             var expression = spec.ToExpression();
 
             // Act
-            await Easify.Ef.Extensions.RepositoryExtensions.GetFirstOrDefaultAsync(repository, spec, q => q);
+            await repository.GetFirstOrDefaultAsync(spec, q => q);
 
             // Assert
             await repository.Received(1).GetFirstOrDefaultAsync(Arg.Is((Expression<Func<SampleEntity, bool>> m)  => m.ToString() == expression.ToString()),

--- a/src/Easify.Ef/Easify.Ef.csproj
+++ b/src/Easify.Ef/Easify.Ef.csproj
@@ -8,14 +8,18 @@
     <PackageProjectUrl>https://github.com/icgam/Easify.Ef</PackageProjectUrl>
     <RepositoryUrl>https://github.com/icgam/Easify.Ef</RepositoryUrl>
     <Version>1.0.0</Version>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Easify.Extensions" Version="1.1.0" />
-    <PackageReference Include="Easify.Http" Version="1.1.0" />
-    <PackageReference Include="EfCore.UnitOfWork" Version="1.0.15" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.0.3" />
+    <PackageReference Include="Easify.Extensions" Version="3.0.1" />
+    <PackageReference Include="Easify.Http" Version="3.0.1" />
+    <PackageReference Include="EfCore.UnitOfWork" Version="3.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.9">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.9" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The PR includes the changes to migrate the library to use .NET Core 3.1 and EF Core 3.1.

- Closing #8 
- Closing #9 

New Features

- #9 - Support for EF Core 3.1

Fixes

- #8 - Error when using the specification patterns to be enforced to use ToExpression. **In fact, this is not a bug and importing Easify.Ef.Extensions namespace will fix the issue.**

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

It's been tested through unit and integration tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
